### PR TITLE
Add support for archiving task list

### DIFF
--- a/src/main/java/duke/command/ArchiveCommand.java
+++ b/src/main/java/duke/command/ArchiveCommand.java
@@ -1,0 +1,58 @@
+package duke.command;
+
+import duke.exception.DukeException;
+import duke.io.FileStorage;
+import duke.io.Storage;
+import duke.task.TaskList;
+
+import java.nio.file.Path;
+
+/**
+ * Represents an archive command for archiving the task list into a file and deleting all tasks tracked by the app.
+ */
+public class ArchiveCommand implements Command {
+    /**
+     * Archives the task list to a file at the path specified in input, then clears the task list.
+     *
+     * @param input {@inheritDoc}
+     * @param tasks {@inheritDoc}
+     * @return An acknowledgement message.
+     * @throws DukeException Indicates failure to write to file or no path was specified in input.
+     */
+    @Override
+    public String run(String input, TaskList tasks) throws DukeException {
+        Storage storage = createStorage(input);
+
+        tasks.save(storage);
+        tasks.clear();
+
+        return "And poof! All gone! All your tasks are gone.";
+    }
+
+    private Storage createStorage(String input) throws DukeException {
+        String path = extractSavePath(input);
+
+        Storage storage = new FileStorage(Path.of(path));
+        storage.create();
+
+        return storage;
+    }
+
+    private String extractSavePath(String input) throws DukeException {
+        assert input != null;
+
+        String path = input.replaceFirst("archive", "").trim();
+
+        validateNonEmptyPath(path);
+
+        return path;
+    }
+
+    private void validateNonEmptyPath(String path) throws DukeException {
+        assert path != null;
+
+        if (path.isEmpty()) {
+            throw new DukeException("You didn't specify a path to save the archive to!");
+        }
+    }
+}

--- a/src/main/java/duke/command/Parser.java
+++ b/src/main/java/duke/command/Parser.java
@@ -25,6 +25,7 @@ public class Parser {
         strToCommand.put("unmark", new UnmarkCommand());
         strToCommand.put("find", new FindCommand());
         strToCommand.put("list", new ListCommand());
+        strToCommand.put("archive", new ArchiveCommand());
         strToCommand.put("bye", new ByeCommand());
     }
 

--- a/src/main/java/duke/io/FileStorage.java
+++ b/src/main/java/duke/io/FileStorage.java
@@ -41,6 +41,7 @@ public class FileStorage implements Storage {
         } catch (FileAlreadyExistsException e) {
             // Nothing to do as the file already exist
         } catch (IOException e) {
+            System.out.println(e);
             throw new DukeException("I encountered an I/O error when creating the save file!");
         } catch (SecurityException e) {
             throw new DukeException("I do not have enough permissions to create the save file!");

--- a/src/main/java/duke/task/TaskList.java
+++ b/src/main/java/duke/task/TaskList.java
@@ -108,7 +108,7 @@ public class TaskList {
     }
 
     /**
-     * Updates the task at index.
+     * Updates the task at index and writes the updated task list to storage.
      *
      * @param index The index of the task to be updated.
      * @param task The updated task.
@@ -125,6 +125,33 @@ public class TaskList {
             writeToStorage();
         } catch (DukeException e) {
             tasks.set(index, oldTask);
+            throw e;
+        }
+    }
+
+    /**
+     * Writes the task list to the specified storage.
+     *
+     * @param storage The storage to write to.
+     * @throws DukeException Indicates failure to write to the specified storage.
+     */
+    public void save(Storage storage) throws DukeException {
+        writeToStorage(storage);
+    }
+
+    /**
+     * Deletes all tasks in the task list and writes the empty task list to storage.
+     *
+     * @throws DukeException Indicates failure to write to storage.
+     */
+    public void clear() throws DukeException {
+        List<Task> oldTasks = tasks;
+        tasks = new ArrayList<Task>();
+
+        try {
+            writeToStorage();
+        } catch (DukeException e) {
+            tasks = oldTasks;
             throw e;
         }
     }
@@ -167,6 +194,12 @@ public class TaskList {
     }
 
     private void writeToStorage() throws DukeException {
+        writeToStorage(storage);
+    }
+
+    private void writeToStorage(Storage storage) throws DukeException {
+        assert storage != null;
+
         StringBuilder data = new StringBuilder();
 
         for (Task task : tasks) {


### PR DESCRIPTION
The user may have completed all tasks in the task list but do not want to lose the data on the task by deleting all of them.

Let's
* add an ArchiveCommand class that handles archiving the user's task list to a file and clears the task list
* change Parser class to run ArchiveCommand::run(String, TaskList) whenever the user's input begins with "archive"

By encapsulating the logic for archiving the task list into the ArchiveCommand, we can make it easier for developers to find said logic. It also allows complies with the single-responsibility principle.